### PR TITLE
Add interactive DebtWise dashboard frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# DebtWise AI Backend Prototype
+
+DebtWise AI is a debt management and intelligent repayment planning platform. This repository contains a standalone Node.js backend implemented without third-party dependencies to satisfy restricted runtime environments. The service exposes REST-style endpoints for authentication, debt CRUD, repayment simulations (snowball & avalanche), reminders, and analytics.
+
+## Features
+
+- **User Management** – registration, login, profile updates, and membership upgrades (free vs. premium).
+- **Debt Management** – create, update, delete debts with balance tracking, payment history, and membership-based limits.
+- **Repayment Strategies** – deterministic simulation of snowball and avalanche strategies with payoff timelines and interest projections.
+- **Reminders & Notifications** – automatic upcoming due-date reminders plus user-defined custom reminders.
+- **Analytics & Visualisation Support** – aggregated metrics for totals, distributions, and payment trends to power dashboard charts.
+- **Offline-Friendly Storage** – JSON file persistence (`data/db.json`) to keep the project runnable without external services.
+- **Interactive Dashboard** – a built-in front-end module that renders live debt summaries, visualisations, strategy comparisons, and reminder timelines.
+
+## Getting Started
+
+```bash
+npm install # no-op (zero external dependencies)
+npm run dev
+```
+
+The API listens on port `4000` by default. Override with `PORT=5000 npm run dev`.
+
+While the server is running, open `http://localhost:4000/` to explore the DebtWise AI dashboard. The interface supports logging in with API credentials or loading the built-in demo dataset for a quick tour.
+
+### Key Endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `POST` | `/auth/register` | Create a new user account. |
+| `POST` | `/auth/login` | Obtain an access token. |
+| `GET` | `/users/me` | Retrieve authenticated user profile. |
+| `POST` | `/debts` | Create a debt (free tier limited to 5 debts). |
+| `POST` | `/debts/:id/payments` | Record a payment and update balance. |
+| `POST` | `/strategies/simulate` | Run snowball or avalanche simulations. |
+| `GET` | `/analytics/summary` | Fetch totals and payoff progress. |
+| `GET` | `/reminders/upcoming` | List automatic and custom reminders. |
+
+Authentication relies on a bearer token returned by login/registration responses.
+
+## Running Tests
+
+```bash
+npm test
+```
+
+Node's built-in test runner validates repayment strategy calculations and error handling.
+
+## Frontend Dashboard Overview
+
+- **Auth & Demo Mode** – log in with existing API users or preview the experience instantly with curated demo data.
+- **Debt Overview** – responsive KPI cards highlight total principal, outstanding balance, repayments, progress, and upcoming due dates.
+- **Strategy Simulation** – adjust monthly budgets and compare snowball vs. avalanche plans with payoff timelines and interest impact visualised side-by-side.
+- **Data Visualisation** – CSS-powered pie and line charts illustrate debt distribution and repayment velocity without external dependencies.
+- **Reminders Timeline** – consolidated feed for automated and custom alerts helps prevent overdue penalties.
+
+## Project Structure
+
+```
+src/
+  algorithms/       # Snowball & avalanche simulation logic
+  services/         # Domain services operating on the data store
+  routes/           # HTTP route registrations
+  http/router.js    # Minimal routing & auth layer
+  storage/          # File-based persistence
+  utils/            # Shared helpers (JWT, validation, etc.)
+data/db.json        # Persistent storage
+```
+
+## Roadmap
+
+- Replace JSON storage with Postgres or Firestore adapters.
+- Add push notification integrations (APNs/FCM).
+- Provide PDF export and predictive analytics for premium tier (v2 goals).
+
+## Security Notes
+
+- Passwords are hashed with PBKDF2 (120k iterations, SHA-512).
+- JWT generation implemented with HMAC-SHA256 and configurable expiry.
+- Ensure the default secret (`JWT_SECRET`) is overridden in production deployments.

--- a/data/db.json
+++ b/data/db.json
@@ -1,0 +1,6 @@
+{
+  "users": [],
+  "debts": [],
+  "payments": [],
+  "reminders": []
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,95 @@
+# DebtWise AI Architecture Overview
+
+## High-Level Design
+
+```
+┌────────────────────┐     ┌──────────────────┐
+│  Mobile / Web App  │◀───▶│  RESTful API     │
+│ (React Native &    │     │  (Node.js)       │
+│  Web Dashboard)    │     │                  │
+└────────────────────┘     └──────────────────┘
+                                 │
+                                 ▼
+                       ┌──────────────────┐
+                       │  Storage Layer   │
+                       │ (JSON in V1,     │
+                       │  DB adapter V2)  │
+                       └──────────────────┘
+```
+
+The backend exposes stateless JSON endpoints; clients authenticate using JWT bearer tokens. The storage layer is abstracted in `services/` to facilitate swapping the JSON file for PostgreSQL or Firestore without modifying business logic.
+
+## Modules
+
+| Module | Responsibilities |
+| ------ | ---------------- |
+| `algorithms/` | Financial simulations for snowball and avalanche repayment strategies. |
+| `services/` | Business logic for authentication, debts, reminders, analytics, and strategy orchestration. |
+| `http/router.js` | Lightweight request router with body parsing, route matching, and authentication guard. |
+| `http/static.js` | Serves the bundled dashboard assets without external dependencies. |
+| `routes/` | HTTP endpoint definitions mapping to services. |
+| `storage/database.js` | File-backed persistence abstraction used for local development and testing. |
+| `frontend/` | Vanilla JS dashboard presenting debt KPIs, charts, strategy comparisons, and reminders. |
+| `utils/` | Shared utilities: JWT signing, PBKDF2 password hashing, validation helpers, and date formatting. |
+
+The `frontend/` directory contains a custom element (`<debtwise-dashboard>`) that reuses the public REST endpoints to render a responsive UI, while also offering an offline demo mode for showcasing core scenarios without seeding the database.
+
+## Data Model
+
+### Users
+
+```
+{
+  id: string,
+  email: string,
+  passwordHash: string,
+  name: string,
+  income: number,
+  expenses: number,
+  reminderPreferences: {
+    daysBeforeDue: number,
+    timeOfDay: "HH:MM"
+  },
+  membership: "free" | "premium",
+  createdAt: ISODate,
+  updatedAt: ISODate
+}
+```
+
+### Debts
+
+```
+{
+  id: string,
+  userId: string,
+  name: string,
+  principal: number,
+  apr: number,
+  minimumPayment: number,
+  dueDate: ISODate,
+  type: "credit_card" | "loan" | ...,
+  balance: number,
+  totalPaid: number,
+  lastPaymentAt: ISODate | null,
+  createdAt: ISODate,
+  updatedAt: ISODate
+}
+```
+
+### Payments & Reminders
+
+Payments capture `amount`, `paidAt`, and optional notes. Reminders include both system-generated (based on preferences) and user-created events.
+
+## Security Considerations
+
+- PBKDF2 password hashing with per-user salts.
+- JWT tokens signed using HMAC-SHA256 with configurable expiration.
+- Membership gates (free vs. premium) enforced at service layer.
+- Input validation performed by hand-rolled validators to avoid external dependencies.
+
+## Future Extensions
+
+1. **Database Adapter** – Implement repository interfaces for Postgres/Firestore.
+2. **Push Notifications** – Integrate APNs/FCM for real-time reminders.
+3. **Advanced Analytics** – Add AI-assisted payoff suggestions and PDF export for premium members.
+4. **Monitoring & Logging** – Plug into centralized logging (e.g., OpenTelemetry) and health checks.

--- a/frontend/components/DebtWiseDashboard.js
+++ b/frontend/components/DebtWiseDashboard.js
@@ -1,0 +1,871 @@
+const PALETTE = ['#38bdf8', '#34d399', '#fbbf24', '#f472b6', '#a855f7', '#94a3b8'];
+const TYPE_LABELS = {
+  credit_card: '信用卡',
+  loan: '信用貸款',
+  mortgage: '房貸',
+  auto: '車貸',
+  student: '學貸',
+  other: '其他',
+};
+const STATUS_LABELS = {
+  active: '進行中',
+  paid: '已結清',
+  overdue: '逾期',
+};
+
+function formatCurrency(value) {
+  const number = Number.isFinite(value) ? value : 0;
+  return new Intl.NumberFormat('zh-TW', {
+    style: 'currency',
+    currency: 'TWD',
+    maximumFractionDigits: number >= 100000 ? 0 : 2,
+  }).format(number);
+}
+
+function formatPercent(value) {
+  const number = Number.isFinite(value) ? value : 0;
+  return `${number.toFixed(1)}%`;
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  try {
+    const date = new Date(value);
+    return date.toLocaleDateString('zh-TW', { year: 'numeric', month: 'short', day: 'numeric' });
+  } catch (error) {
+    return value;
+  }
+}
+
+function clampPercent(value) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+}
+
+function toLabel(type) {
+  return TYPE_LABELS[type] || TYPE_LABELS.other;
+}
+
+function statusLabel(status) {
+  return STATUS_LABELS[status] || status;
+}
+
+function buildGradient(distribution) {
+  if (!distribution || distribution.length === 0) {
+    return 'conic-gradient(#1e293b 0deg, #1e293b 360deg)';
+  }
+  const total = distribution.reduce((sum, item) => sum + (item.balance || item.principal || 0), 0) || 1;
+  let cursor = 0;
+  const segments = distribution.map((item, index) => {
+    const value = item.balance || item.principal || 0;
+    const degrees = (value / total) * 360;
+    const start = cursor;
+    cursor += degrees;
+    const color = PALETTE[index % PALETTE.length];
+    return `${color} ${start.toFixed(2)}deg ${cursor.toFixed(2)}deg`;
+  });
+  return `conic-gradient(${segments.join(', ')})`;
+}
+
+function buildPolyline(trends) {
+  if (!trends || !Array.isArray(trends.paid) || trends.paid.length === 0) {
+    return { width: 480, height: 220, points: '', labels: '' };
+  }
+  const width = 520;
+  const height = 220;
+  const padding = 32;
+  const values = trends.paid.map((value) => (Number.isFinite(value) ? value : 0));
+  const maxValue = Math.max(...values, 1);
+  const step = trends.paid.length > 1 ? (width - padding * 2) / (trends.paid.length - 1) : 0;
+  const points = values
+    .map((value, index) => {
+      const x = padding + step * index;
+      const y = height - padding - (value / maxValue) * (height - padding * 1.6);
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+  const labels = (trends.months || [])
+    .map((label, index) => {
+      const x = padding + step * index;
+      return `<text x="${x}" y="${height - 10}" font-size="12" fill="rgba(226,232,240,0.7)" text-anchor="middle">${label}</text>`;
+    })
+    .join('');
+  return { width, height, points, labels };
+}
+
+function createDemoData() {
+  const now = new Date();
+  const nextMonth = new Date(now);
+  nextMonth.setMonth(now.getMonth() + 1, 5);
+  const twoMonths = new Date(now);
+  twoMonths.setMonth(now.getMonth() + 2, 18);
+  return {
+    user: {
+      id: 'demo-user',
+      name: '陳艾達',
+      email: 'ada.chen@example.com',
+      membership: 'premium',
+      reminderPreferences: { daysBeforeDue: 3, timeOfDay: '09:00' },
+    },
+    summary: {
+      totals: {
+        principal: 680000,
+        balance: 248600,
+        paid: 431400,
+        averageApr: 7.8,
+      },
+      progress: 63.5,
+      nextDueDebt: {
+        id: 'debt-cc',
+        name: '花旗現金回饋卡',
+        dueDate: nextMonth.toISOString(),
+        balance: 38600,
+      },
+      debtsCount: 4,
+    },
+    debts: [
+      {
+        id: 'debt-cc',
+        name: '花旗現金回饋卡',
+        principal: 85000,
+        balance: 38600,
+        apr: 15.9,
+        minimumPayment: 3200,
+        dueDate: nextMonth.toISOString(),
+        type: 'credit_card',
+        progress: 54.6,
+        totalPaid: 46400,
+        status: 'active',
+      },
+      {
+        id: 'debt-loan',
+        name: '個人信貸',
+        principal: 220000,
+        balance: 92000,
+        apr: 6.4,
+        minimumPayment: 7800,
+        dueDate: twoMonths.toISOString(),
+        type: 'loan',
+        progress: 58.2,
+        totalPaid: 128000,
+        status: 'active',
+      },
+      {
+        id: 'debt-auto',
+        name: '車貸',
+        principal: 180000,
+        balance: 32400,
+        apr: 5.1,
+        minimumPayment: 5200,
+        dueDate: nextMonth.toISOString(),
+        type: 'auto',
+        progress: 82,
+        totalPaid: 147600,
+        status: 'active',
+      },
+      {
+        id: 'debt-student',
+        name: '學貸',
+        principal: 195000,
+        balance: 85600,
+        apr: 2.2,
+        minimumPayment: 3500,
+        dueDate: twoMonths.toISOString(),
+        type: 'student',
+        progress: 56.1,
+        totalPaid: 109400,
+        status: 'active',
+      },
+    ],
+    distribution: [
+      { type: 'credit_card', principal: 85000, balance: 38600 },
+      { type: 'loan', principal: 220000, balance: 92000 },
+      { type: 'auto', principal: 180000, balance: 32400 },
+      { type: 'student', principal: 195000, balance: 85600 },
+    ],
+    trends: {
+      months: ['2023-12', '2024-01', '2024-02', '2024-03', '2024-04', '2024-05'],
+      paid: [22000, 23500, 24800, 25000, 25500, 26800],
+      payments: [4, 4, 5, 4, 5, 5],
+    },
+    reminders: [
+      {
+        id: 'demo-reminder-1',
+        title: 'Upcoming payment: 花旗現金回饋卡',
+        debtId: 'debt-cc',
+        notifyAt: nextMonth.toISOString(),
+        dueDate: nextMonth.toISOString(),
+        amountDue: 3200,
+        type: 'system',
+      },
+      {
+        id: 'demo-reminder-2',
+        title: '車貸自動扣繳確認',
+        debtId: 'debt-auto',
+        notifyAt: nextMonth.toISOString(),
+        dueDate: nextMonth.toISOString(),
+        amountDue: 5200,
+        type: 'custom',
+      },
+    ],
+    strategy: {
+      monthlyBudget: 26000,
+      snowball: {
+        strategy: 'snowball',
+        totalInterest: 42850,
+        months: 16,
+        payoffDate: new Date(now.getFullYear(), now.getMonth() + 16, 1).toISOString(),
+        debtSummaries: [
+          { id: 'debt-cc', name: '花旗現金回饋卡', months: 4, interest: 3860, payoffDate: new Date(now.getFullYear(), now.getMonth() + 4, 1).toISOString() },
+          { id: 'debt-auto', name: '車貸', months: 8, interest: 5200, payoffDate: new Date(now.getFullYear(), now.getMonth() + 8, 1).toISOString() },
+          { id: 'debt-loan', name: '個人信貸', months: 12, interest: 16240, payoffDate: new Date(now.getFullYear(), now.getMonth() + 12, 1).toISOString() },
+          { id: 'debt-student', name: '學貸', months: 16, interest: 17550, payoffDate: new Date(now.getFullYear(), now.getMonth() + 16, 1).toISOString() },
+        ],
+      },
+      avalanche: {
+        strategy: 'avalanche',
+        totalInterest: 35120,
+        months: 14,
+        payoffDate: new Date(now.getFullYear(), now.getMonth() + 14, 1).toISOString(),
+        debtSummaries: [
+          { id: 'debt-cc', name: '花旗現金回饋卡', months: 5, interest: 3420, payoffDate: new Date(now.getFullYear(), now.getMonth() + 5, 1).toISOString() },
+          { id: 'debt-auto', name: '車貸', months: 10, interest: 4800, payoffDate: new Date(now.getFullYear(), now.getMonth() + 10, 1).toISOString() },
+          { id: 'debt-loan', name: '個人信貸', months: 14, interest: 15400, payoffDate: new Date(now.getFullYear(), now.getMonth() + 14, 1).toISOString() },
+          { id: 'debt-student', name: '學貸', months: 14, interest: 11500, payoffDate: new Date(now.getFullYear(), now.getMonth() + 14, 1).toISOString() },
+        ],
+      },
+      interestSavings: 7730,
+      monthsDifference: 2,
+    },
+  };
+}
+
+class DebtWiseDashboard extends HTMLElement {
+  constructor() {
+    super();
+    this.state = {
+      token: '',
+      user: null,
+      summary: null,
+      debts: [],
+      distribution: [],
+      trends: null,
+      reminders: [],
+      strategy: null,
+      monthlyBudget: 20000,
+      loading: false,
+      error: '',
+      useDemo: false,
+      lastSync: null,
+    };
+    this._apiBase = '';
+    this._isMounted = false;
+  }
+
+  connectedCallback() {
+    if (this._isMounted) return;
+    this._isMounted = true;
+    this.restoreSession();
+    this.render();
+    if (this.state.token) {
+      this.fetchAll();
+    }
+  }
+
+  set apiBase(value) {
+    if (typeof value === 'string') {
+      this._apiBase = value.replace(/\/$/, '');
+    }
+  }
+
+  get apiBase() {
+    return this._apiBase || '';
+  }
+
+  resolveUrl(path) {
+    if (!path.startsWith('/')) {
+      return `${this.apiBase}${path}`;
+    }
+    if (!this.apiBase) {
+      return path;
+    }
+    return `${this.apiBase}${path}`;
+  }
+
+  restoreSession() {
+    try {
+      const session = window.localStorage && window.localStorage.getItem('debtwiseSession');
+      if (session) {
+        const parsed = JSON.parse(session);
+        this.state = {
+          ...this.state,
+          token: parsed.token || '',
+          user: parsed.user || null,
+          monthlyBudget: parsed.monthlyBudget || this.state.monthlyBudget,
+        };
+        if (parsed.apiBase) {
+          this._apiBase = parsed.apiBase;
+        }
+      }
+    } catch (error) {
+      // ignore persistence errors
+    }
+  }
+
+  persistSession(user) {
+    try {
+      if (this.state.token) {
+        window.localStorage.setItem(
+          'debtwiseSession',
+          JSON.stringify({
+            token: this.state.token,
+            user,
+            apiBase: this.apiBase,
+            monthlyBudget: this.state.monthlyBudget,
+          })
+        );
+      }
+    } catch (error) {
+      // ignore persistence errors
+    }
+  }
+
+  clearSession() {
+    try {
+      window.localStorage.removeItem('debtwiseSession');
+    } catch (error) {
+      // ignore
+    }
+  }
+
+  setState(patch) {
+    this.state = { ...this.state, ...patch };
+    this.render();
+  }
+
+  async request(path, options = {}, includeAuth = true) {
+    const headers = { Accept: 'application/json', ...(options.headers || {}) };
+    let body = options.body;
+    if (body && typeof body === 'object' && !(body instanceof FormData)) {
+      headers['Content-Type'] = 'application/json';
+      body = JSON.stringify(body);
+    }
+    if (includeAuth && this.state.token) {
+      headers.Authorization = `Bearer ${this.state.token}`;
+    }
+    const response = await fetch(this.resolveUrl(path), { ...options, headers, body });
+    if (!response.ok) {
+      let message = `Request failed (${response.status})`;
+      try {
+        const data = await response.json();
+        if (data && data.error && data.error.message) {
+          message = data.error.message;
+        }
+      } catch (error) {
+        // ignore JSON parse error
+      }
+      throw new Error(message);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    return response.json();
+  }
+
+  async handleLogin(form) {
+    const formData = new FormData(form);
+    const email = String(formData.get('email') || '').trim();
+    const password = String(formData.get('password') || '').trim();
+    const api = String(formData.get('api') || '').trim();
+    if (api) {
+      this.apiBase = api;
+    }
+    if (!email || !password) {
+      this.setState({ error: '請輸入 Email 與密碼。' });
+      return;
+    }
+    this.setState({ loading: true, error: '' });
+    try {
+      const result = await this.request(
+        '/auth/login',
+        { method: 'POST', body: { email, password } },
+        false
+      );
+      this.setState({ token: result.token, user: result.user, loading: false, useDemo: false });
+      this.persistSession(result.user);
+      await this.fetchAll();
+    } catch (error) {
+      this.setState({ loading: false, error: error.message || '登入失敗，請稍後再試。' });
+    }
+  }
+
+  async fetchAll() {
+    if (!this.state.token) return;
+    this.setState({ loading: true, error: '' });
+    try {
+      const [profile, summary, debts, distribution, trends, reminders] = await Promise.all([
+        this.request('/users/me'),
+        this.request('/analytics/summary'),
+        this.request('/debts'),
+        this.request('/analytics/distribution'),
+        this.request('/analytics/trends'),
+        this.request('/reminders/upcoming'),
+      ]);
+      const strategy = await this.request('/strategies/compare', {
+        method: 'POST',
+        body: {
+          monthlyBudget: this.state.monthlyBudget,
+        },
+      });
+      this.setState({
+        user: profile.user,
+        summary,
+        debts: debts.debts || [],
+        distribution: distribution.distribution || [],
+        trends,
+        reminders: reminders.reminders || [],
+        strategy,
+        loading: false,
+        error: '',
+        useDemo: false,
+        lastSync: new Date().toISOString(),
+      });
+      this.persistSession(profile.user);
+    } catch (error) {
+      this.setState({ loading: false, error: error.message || '無法載入儀表板資料。' });
+    }
+  }
+
+  async refreshStrategy(budget) {
+    if (this.state.useDemo) {
+      const demo = createDemoData();
+      this.setState({
+        monthlyBudget: budget,
+        strategy: { ...demo.strategy, monthlyBudget: budget },
+      });
+      return;
+    }
+    if (!this.state.token) return;
+    this.setState({ loading: true, error: '' });
+    try {
+      const strategy = await this.request('/strategies/compare', {
+        method: 'POST',
+        body: {
+          monthlyBudget: budget,
+        },
+      });
+      this.setState({ strategy, monthlyBudget: budget, loading: false, lastSync: new Date().toISOString() });
+      this.persistSession(this.state.user);
+    } catch (error) {
+      this.setState({ loading: false, error: error.message || '試算失敗，請確認債務資料。' });
+    }
+  }
+
+  loadDemoData() {
+    const demo = createDemoData();
+    this.setState({
+      token: '',
+      user: demo.user,
+      summary: demo.summary,
+      debts: demo.debts,
+      distribution: demo.distribution,
+      trends: demo.trends,
+      reminders: demo.reminders,
+      strategy: demo.strategy,
+      useDemo: true,
+      monthlyBudget: demo.strategy.monthlyBudget,
+      loading: false,
+      error: '',
+      lastSync: new Date().toISOString(),
+    });
+    this.clearSession();
+  }
+
+  logout() {
+    this.clearSession();
+    this.setState({
+      token: '',
+      user: null,
+      summary: null,
+      debts: [],
+      distribution: [],
+      trends: null,
+      reminders: [],
+      strategy: null,
+      useDemo: false,
+      loading: false,
+      error: '',
+      lastSync: null,
+    });
+  }
+
+  bindEvents() {
+    const loginForm = this.querySelector('#login-form');
+    if (loginForm) {
+      loginForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        this.handleLogin(loginForm);
+      });
+    }
+    const refreshButton = this.querySelector('#refresh-dashboard');
+    if (refreshButton) {
+      refreshButton.addEventListener('click', () => {
+        if (this.state.useDemo) {
+          this.loadDemoData();
+        } else {
+          this.fetchAll();
+        }
+      });
+    }
+    const logoutButton = this.querySelector('#logout-button');
+    if (logoutButton) {
+      logoutButton.addEventListener('click', () => this.logout());
+    }
+    const demoButton = this.querySelector('#demo-button');
+    if (demoButton) {
+      demoButton.addEventListener('click', () => this.loadDemoData());
+    }
+    const budgetForm = this.querySelector('#budget-form');
+    if (budgetForm) {
+      budgetForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const formData = new FormData(budgetForm);
+        const value = Number.parseFloat(String(formData.get('budget')) || '0');
+        if (!Number.isFinite(value) || value <= 0) {
+          this.setState({ error: '請輸入有效的月度還款預算。' });
+          return;
+        }
+        this.refreshStrategy(value);
+      });
+    }
+  }
+
+  renderHero() {
+    const { user, summary, useDemo, loading, lastSync } = this.state;
+    const membership = user && user.membership ? user.membership : 'free';
+    const memberLabel = membership === 'premium' ? '付費版會員' : '免費版會員';
+    const progress = summary ? clampPercent(summary.progress) : 0;
+    return `
+      <section class="hero">
+        <div class="tag-list">
+          <span class="tag">DebtWise AI</span>
+          <span class="tag">${memberLabel}</span>
+          ${useDemo ? '<span class="tag">Demo 模式</span>' : ''}
+        </div>
+        <h1>${user ? `${user.name || user.email} 的債務儀表板` : '掌握債務、降低壓力'}</h1>
+        <p>一次掌握債務總覽、還款策略試算與提醒通知，打造屬於你的智慧理財教練。</p>
+        <div class="actions">
+          <button class="primary" id="refresh-dashboard" ${loading ? 'disabled' : ''}>${loading ? '同步中...' : '重新整理資料'}</button>
+          ${this.state.token ? '<button class="secondary" id="logout-button">登出</button>' : ''}
+        </div>
+        ${summary ? `<div class="footer-note">目前整體清償進度 ${formatPercent(progress)}${lastSync ? ` · 上次同步 ${formatDate(lastSync)}` : ''}</div>` : ''}
+      </section>
+    `;
+  }
+
+  renderSummary() {
+    const { summary } = this.state;
+    if (!summary) {
+      return '';
+    }
+    const cards = [
+      { label: '總本金', value: formatCurrency(summary.totals.principal) },
+      { label: '剩餘餘額', value: formatCurrency(summary.totals.balance) },
+      { label: '已償還', value: formatCurrency(summary.totals.paid) },
+      { label: '平均年利率', value: `${summary.totals.averageApr.toFixed(2)}%` },
+    ];
+    const nextDue = summary.nextDueDebt
+      ? `<div class="badge warning">下一筆到期：${summary.nextDueDebt.name} · ${formatDate(summary.nextDueDebt.dueDate)}</div>`
+      : '<div class="badge positive">所有債務皆為最新狀態</div>';
+    const progress = clampPercent(summary.progress);
+    return `
+      <section class="card">
+        <h2>債務概況</h2>
+        <div class="stats">
+          ${cards
+            .map(
+              (card) => `
+              <div class="stat">
+                <span class="label">${card.label}</span>
+                <span class="value">${card.value}</span>
+              </div>
+            `
+            )
+            .join('')}
+        </div>
+        <div class="badge positive" style="margin-top:16px;">整體清償進度 ${formatPercent(progress)}</div>
+        <div style="margin-top:12px;">${nextDue}</div>
+      </section>
+    `;
+  }
+
+  renderDebts() {
+    const { debts } = this.state;
+    if (!debts || debts.length === 0) {
+      return `
+        <section class="card">
+          <h2>債務清單</h2>
+          <p>目前沒有債務資料，請先建立債務或載入示範資料。</p>
+        </section>
+      `;
+    }
+    const rows = debts
+      .map((debt) => {
+        const progressWidth = clampPercent(debt.progress);
+        return `
+          <tr>
+            <td>${debt.name}</td>
+            <td>${toLabel(debt.type)}</td>
+            <td>${formatCurrency(debt.balance)}</td>
+            <td>${debt.apr.toFixed(2)}%</td>
+            <td>${formatCurrency(debt.minimumPayment)}</td>
+            <td>${formatDate(debt.dueDate)}</td>
+            <td class="status">${statusLabel(debt.status)}</td>
+            <td style="min-width:120px;">
+              <div class="progress-bar"><span style="width:${progressWidth}%"></span></div>
+            </td>
+          </tr>
+        `;
+      })
+      .join('');
+    return `
+      <section class="card">
+        <h2>債務清單</h2>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>名稱</th>
+                <th>類型</th>
+                <th>目前餘額</th>
+                <th>APR</th>
+                <th>最低還款</th>
+                <th>到期日</th>
+                <th>狀態</th>
+                <th>進度</th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      </section>
+    `;
+  }
+
+  renderDistribution() {
+    const { distribution } = this.state;
+    if (!distribution || distribution.length === 0) {
+      return `
+        <section class="card">
+          <h2>債務分佈</h2>
+          <p>尚無資料可供分析。</p>
+        </section>
+      `;
+    }
+    const total = distribution.reduce((sum, item) => sum + (item.balance || item.principal || 0), 0) || 1;
+    const gradient = buildGradient(distribution);
+    const legend = distribution
+      .map((item, index) => {
+        const color = PALETTE[index % PALETTE.length];
+        const amount = item.balance || item.principal || 0;
+        const percent = ((amount / total) * 100).toFixed(1);
+        return `<li><span class="swatch" style="background:${color}"></span>${toLabel(item.type)} · ${percent}%</li>`;
+      })
+      .join('');
+    return `
+      <section class="card">
+        <h2>債務分佈圓餅圖</h2>
+        <div class="chart">
+          <div class="pie" style="background:${gradient};"></div>
+          <ul class="legend">${legend}</ul>
+        </div>
+      </section>
+    `;
+  }
+
+  renderTrends() {
+    const { trends } = this.state;
+    if (!trends || !Array.isArray(trends.paid) || trends.paid.length === 0) {
+      return `
+        <section class="card">
+          <h2>總額趨勢</h2>
+          <p>尚未記錄任何還款，完成首次付款後會顯示趨勢分析。</p>
+        </section>
+      `;
+    }
+    const { width, height, points, labels } = buildPolyline(trends);
+    return `
+      <section class="card">
+        <h2>總額趨勢</h2>
+        <div class="line-chart">
+          <svg viewBox="0 0 ${width} ${height}">
+            <polyline points="${points}" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></polyline>
+            ${labels}
+          </svg>
+        </div>
+        <p class="footer-note">最近 ${trends.months.length} 個月累計還款 ${formatCurrency(trends.paid.reduce((sum, value) => sum + value, 0))}</p>
+      </section>
+    `;
+  }
+
+  renderReminders() {
+    const { reminders } = this.state;
+    if (!reminders || reminders.length === 0) {
+      return `
+        <section class="card">
+          <h2>提醒通知</h2>
+          <p>目前沒有即將到期的提醒。</p>
+        </section>
+      `;
+    }
+    const items = reminders
+      .map((reminder) => {
+        const amount = reminder.amountDue ? `<span class="meta">建議付款：${formatCurrency(reminder.amountDue)}</span>` : '';
+        const due = reminder.dueDate ? `<span class="meta">到期日：${formatDate(reminder.dueDate)}</span>` : '';
+        return `
+          <div class="reminder">
+            <span class="title">${reminder.title}</span>
+            <span class="meta">提醒時間：${formatDate(reminder.notifyAt)}</span>
+            ${due}
+            ${amount}
+            <span class="meta">來源：${reminder.type === 'custom' ? '自訂提醒' : '系統提醒'}</span>
+          </div>
+        `;
+      })
+      .join('');
+    return `
+      <section class="card">
+        <h2>提醒通知</h2>
+        <div class="reminders">${items}</div>
+      </section>
+    `;
+  }
+
+  renderStrategy() {
+    const { strategy, monthlyBudget } = this.state;
+    const form = `
+      <form id="budget-form" class="actions" style="margin-top:12px;">
+        <label style="display:grid;gap:6px;font-size:0.9rem;color:var(--text-muted);">
+          月度還款預算 (TWD)
+          <input name="budget" type="number" min="1" step="100" value="${monthlyBudget}" style="max-width:200px;" />
+        </label>
+        <button class="primary" type="submit">重新試算</button>
+      </form>
+    `;
+    if (!strategy) {
+      return `
+        <section class="card">
+          <h2>還款策略試算</h2>
+          <p>請輸入月度還款預算後開始試算。</p>
+          ${form}
+        </section>
+      `;
+    }
+    const savingsBadge =
+      strategy.interestSavings >= 0
+        ? `利息差額節省 ${formatCurrency(strategy.interestSavings)}`
+        : `雪崩法增加利息 ${formatCurrency(Math.abs(strategy.interestSavings))}`;
+    let timelineBadge = '兩種策略清償時間相同';
+    if (strategy.monthsDifference > 0) {
+      timelineBadge = `雪崩法可提早 ${strategy.monthsDifference} 個月清償`;
+    } else if (strategy.monthsDifference < 0) {
+      timelineBadge = `雪球法可提早 ${Math.abs(strategy.monthsDifference)} 個月清償`;
+    }
+    const summary = `
+      <div class="badge positive">月預算 ${formatCurrency(strategy.monthlyBudget)} · ${savingsBadge}</div>
+      <div class="badge" style="margin-top:12px;">${timelineBadge}</div>
+    `;
+    const snowball = this.renderStrategyDetail(strategy.snowball, '#34d399');
+    const avalanche = this.renderStrategyDetail(strategy.avalanche, '#38bdf8');
+    return `
+      <section class="card">
+        <h2>還款策略比較</h2>
+        ${summary}
+        <div class="grid two" style="margin-top:16px;">
+          ${snowball}
+          ${avalanche}
+        </div>
+        ${form}
+      </section>
+    `;
+  }
+
+  renderStrategyDetail(result, color) {
+    if (!result) {
+      return '<div>尚無資料</div>';
+    }
+    const list = (result.debtSummaries || [])
+      .map(
+        (item) => `
+          <li>${item.name} · ${item.months} 個月 · 利息 ${formatCurrency(item.interest)} · 完成於 ${formatDate(item.payoffDate)}</li>
+        `
+      )
+      .join('');
+    return `
+      <div class="card" style="background:rgba(15,23,42,0.4); border:1px solid rgba(148,163,184,0.18);">
+        <h3 style="margin-top:0;color:${color};text-transform:uppercase;letter-spacing:0.05em;">${result.strategy}</h3>
+        <p>總利息 ${formatCurrency(result.totalInterest)}</p>
+        <p>清償時間 ${result.months} 個月 · 預估完成日 ${formatDate(result.payoffDate)}</p>
+        <ul style="margin:12px 0 0 18px; color: var(--text-muted); font-size:0.9rem;">
+          ${list}
+        </ul>
+      </div>
+    `;
+  }
+
+  renderAuth() {
+    const defaultApi = this.apiBase || 'http://localhost:4000';
+    return `
+      <section class="card auth-card">
+        <h2>登入 DebtWise AI</h2>
+        <p>使用您在後端建立的帳號登入，或快速載入示範資料。</p>
+        <form id="login-form">
+          <label>
+            電子郵件
+            <input type="email" name="email" placeholder="you@example.com" required />
+          </label>
+          <label>
+            密碼
+            <input type="password" name="password" placeholder="••••••••" required />
+          </label>
+          <label>
+            API 伺服器 (預設為本機)
+            <input type="text" name="api" value="${defaultApi}" />
+          </label>
+          <button class="primary" type="submit" ${this.state.loading ? 'disabled' : ''}>${this.state.loading ? '登入中...' : '登入'}</button>
+        </form>
+        <button class="secondary" id="demo-button">立即體驗示範儀表板</button>
+      </section>
+    `;
+  }
+
+  renderDashboard() {
+    return `
+      ${this.renderSummary()}
+      <section class="grid two">
+        ${this.renderStrategy()}
+        ${this.renderReminders()}
+      </section>
+      <section class="grid two">
+        ${this.renderDebts()}
+        ${this.renderDistribution()}
+      </section>
+      ${this.renderTrends()}
+    `;
+  }
+
+  render() {
+    const { error, token, useDemo } = this.state;
+    const hasData = Boolean(token || useDemo);
+    this.innerHTML = `
+      <div class="dashboard-shell">
+        ${this.renderHero()}
+        ${error ? `<div class="alert">${error}</div>` : ''}
+        ${hasData ? this.renderDashboard() : this.renderAuth()}
+      </div>
+    `;
+    this.bindEvents();
+  }
+}
+
+customElements.define('debtwise-dashboard', DebtWiseDashboard);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DebtWise AI 儀表板</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app" class="page"></div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,8 @@
+import './components/DebtWiseDashboard.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const mount = document.getElementById('app');
+  const dashboard = document.createElement('debtwise-dashboard');
+  dashboard.apiBase = window.location.origin.includes('http') ? '' : 'http://localhost:4000';
+  mount.appendChild(dashboard);
+});

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,393 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --bg-card: rgba(15, 23, 42, 0.75);
+  --bg-card-light: rgba(255, 255, 255, 0.85);
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #34d399;
+  --accent-strong: #16a34a;
+  --accent-soft: rgba(52, 211, 153, 0.18);
+  --text: #f8fafc;
+  --text-muted: rgba(248, 250, 252, 0.68);
+  --shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+  --radius-lg: 24px;
+  --radius-sm: 12px;
+  --max-width: 1180px;
+  font-family: 'Inter', 'Noto Sans TC', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #1e293b, #020617 65%);
+  min-height: 100vh;
+}
+
+.page {
+  padding: 48px 24px 72px;
+  display: flex;
+  justify-content: center;
+}
+
+.dashboard-shell {
+  width: min(100%, var(--max-width));
+  display: grid;
+  gap: 24px;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.12), rgba(51, 65, 85, 0.45));
+  border-radius: var(--radius-lg);
+  padding: 32px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  box-shadow: var(--shadow);
+  color: var(--text);
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 1.8rem + 1vw, 2.6rem);
+  font-weight: 700;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+button.primary,
+button.secondary {
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-size: 0.95rem;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #022c22;
+  font-weight: 600;
+  box-shadow: 0 12px 30px rgba(22, 163, 74, 0.28);
+}
+
+button.primary:disabled {
+  opacity: 0.6;
+  cursor: wait;
+  box-shadow: none;
+}
+
+button.primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+button.secondary {
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.grid {
+  display: grid;
+  gap: 20px;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 24px;
+  color: var(--text);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow);
+}
+
+.card h2 {
+  margin: 0 0 12px;
+  font-size: 1.2rem;
+}
+
+.card p {
+  margin: 4px 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.stats {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stat span.label {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.stat span.value {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.stat .spark {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  position: relative;
+  overflow: hidden;
+}
+
+.stat .spark::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(52, 211, 153, 0.4), rgba(59, 130, 246, 0.4));
+  transform-origin: left;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text);
+}
+
+.badge.positive {
+  background: rgba(34, 197, 94, 0.22);
+  color: #f0fdf4;
+}
+
+.badge.warning {
+  background: rgba(249, 115, 22, 0.22);
+  color: #ffedd5;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  color: var(--text);
+}
+
+table th,
+table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  text-align: left;
+  white-space: nowrap;
+}
+
+table th {
+  color: var(--text-muted);
+  font-weight: 500;
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+table td.status {
+  text-transform: capitalize;
+}
+
+.progress-bar {
+  height: 8px;
+  background: rgba(148, 163, 184, 0.24);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), rgba(14, 165, 233, 0.8));
+}
+
+.reminders {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.reminder {
+  border-radius: var(--radius-sm);
+  padding: 14px 16px;
+  background: rgba(30, 41, 59, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  gap: 4px;
+}
+
+.reminder span.title {
+  font-weight: 600;
+}
+
+.reminder span.meta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.chart {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 20px;
+  align-items: center;
+}
+
+.pie {
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  box-shadow: inset 0 8px 18px rgba(0, 0, 0, 0.45);
+  border: 6px solid rgba(15, 23, 42, 0.45);
+}
+
+.legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-muted);
+}
+
+.legend span.swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+}
+
+.line-chart {
+  width: 100%;
+  height: 220px;
+  background: rgba(15, 23, 42, 0.38);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 12px;
+}
+
+.line-chart svg {
+  width: 100%;
+  height: 100%;
+}
+
+.footer-note {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  margin-top: 10px;
+}
+
+.alert {
+  padding: 14px 18px;
+  border-radius: var(--radius-sm);
+  background: rgba(248, 113, 113, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+  font-size: 0.9rem;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(52, 211, 153, 0.16);
+  color: var(--text);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.auth-card {
+  max-width: 420px;
+  margin: 0 auto;
+  display: grid;
+  gap: 18px;
+  text-align: center;
+}
+
+.auth-card form {
+  display: grid;
+  gap: 12px;
+}
+
+.auth-card label {
+  text-align: left;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  display: grid;
+  gap: 6px;
+}
+
+.auth-card input {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 10px 14px;
+  background: rgba(15, 23, 42, 0.4);
+  color: var(--text);
+}
+
+@media (max-width: 900px) {
+  .chart {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 24px;
+  }
+
+  .card {
+    padding: 20px;
+  }
+
+  .page {
+    padding: 32px 16px 48px;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "debtwise-ai",
+  "version": "1.0.0",
+  "description": "DebtWise AI backend prototype implemented with zero external npm dependencies.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "NODE_ENV=development node src/server.js",
+    "test": "node --test"
+  },
+  "keywords": [
+    "debt",
+    "finance",
+    "planning"
+  ],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/src/algorithms/debtStrategies.js
+++ b/src/algorithms/debtStrategies.js
@@ -1,0 +1,198 @@
+const AppError = require('../errors/AppError');
+const { addMonths, formatISODate, clampToZero } = require('../utils/date');
+
+function normalizeDebts(debts) {
+  if (!Array.isArray(debts) || debts.length === 0) {
+    throw new AppError(400, 'At least one debt is required for simulation.');
+  }
+  return debts.map((debt) => {
+    const balance = Number(debt.balance);
+    const apr = Number(debt.apr);
+    const minimumPayment = Number(debt.minimumPayment);
+    if (Number.isNaN(balance) || balance <= 0) {
+      throw new AppError(400, `Debt ${debt.name || debt.id} must have a positive balance.`);
+    }
+    if (Number.isNaN(apr) || apr < 0) {
+      throw new AppError(400, `Debt ${debt.name || debt.id} must have a valid APR.`);
+    }
+    if (Number.isNaN(minimumPayment) || minimumPayment <= 0) {
+      throw new AppError(400, `Debt ${debt.name || debt.id} must have a positive minimum payment.`);
+    }
+    return {
+      id: debt.id,
+      name: debt.name,
+      balance: Number(balance.toFixed(2)),
+      apr,
+      minimumPayment,
+      type: debt.type,
+      dueDate: debt.dueDate,
+    };
+  });
+}
+
+function orderDebts(debts, strategy) {
+  const cloned = debts.map((debt) => ({ ...debt }));
+  if (strategy === 'snowball') {
+    cloned.sort((a, b) => a.balance - b.balance || a.apr - b.apr);
+  } else if (strategy === 'avalanche') {
+    cloned.sort((a, b) => b.apr - a.apr || a.balance - b.balance);
+  }
+  return cloned;
+}
+
+function simulateStrategy(debtsInput, options) {
+  const debts = normalizeDebts(debtsInput);
+  const { strategy = 'snowball', monthlyBudget, startDate = new Date() } = options;
+  if (strategy !== 'snowball' && strategy !== 'avalanche') {
+    throw new AppError(400, 'Strategy must be either snowball or avalanche.');
+  }
+  const budget = Number(monthlyBudget);
+  if (!budget || budget <= 0) {
+    throw new AppError(400, 'Monthly budget must be a positive number.');
+  }
+  const activeDebts = debts.map((debt) => ({ ...debt }));
+  const debtSummaries = new Map();
+  let monthIndex = 0;
+  const schedule = [];
+  let totalInterest = 0;
+  let totalPaid = 0;
+  const start = new Date(startDate);
+
+  const minimumRequired = activeDebts.reduce((sum, debt) => sum + Math.min(debt.minimumPayment, debt.balance), 0);
+  if (budget + 0.0001 < minimumRequired) {
+    throw new AppError(
+      400,
+      `Monthly budget ${budget.toFixed(2)} is insufficient. Minimum required is ${minimumRequired.toFixed(2)}.`
+    );
+  }
+
+  activeDebts.forEach((debt) => {
+    debtSummaries.set(debt.id, {
+      debtId: debt.id,
+      debtName: debt.name,
+      totalInterest: 0,
+      totalPaid: 0,
+      monthsToPayoff: null,
+      payoffDate: null,
+      startingBalance: debt.balance,
+    });
+  });
+
+  const MAX_MONTHS = 600;
+  while (activeDebts.some((debt) => debt.balance > 0.01)) {
+    if (monthIndex >= MAX_MONTHS) {
+      throw new AppError(400, 'Simulation exceeded maximum supported duration (50 years).');
+    }
+    monthIndex += 1;
+    const currentDate = addMonths(start, monthIndex - 1);
+    const ordered = orderDebts(activeDebts, strategy);
+    const interestMap = new Map();
+
+    let monthInterest = 0;
+    activeDebts.forEach((debt) => {
+      const monthlyRate = debt.apr / 100 / 12;
+      const interest = clampToZero(debt.balance * monthlyRate);
+      debt.balance = clampToZero(debt.balance + interest);
+      monthInterest += interest;
+      interestMap.set(debt.id, interest);
+      const summary = debtSummaries.get(debt.id);
+      summary.totalInterest += interest;
+    });
+
+    let remainingBudget = budget;
+    const payments = [];
+
+    for (const debt of activeDebts) {
+      const minimumPayment = Math.min(debt.minimumPayment, debt.balance);
+      const payment = Math.min(minimumPayment, remainingBudget);
+      debt.balance = clampToZero(debt.balance - payment);
+      remainingBudget = clampToZero(remainingBudget - payment);
+      const summary = debtSummaries.get(debt.id);
+      summary.totalPaid += payment;
+      payments.push({
+        debtId: debt.id,
+        debtName: debt.name,
+        payment: clampToZero(payment),
+        interestAccrued: clampToZero(interestMap.get(debt.id) || 0),
+        balanceRemaining: debt.balance,
+      });
+    }
+
+    for (const debt of ordered) {
+      if (remainingBudget <= 0) {
+        break;
+      }
+      if (debt.balance <= 0) {
+        continue;
+      }
+      const extraPayment = Math.min(debt.balance, remainingBudget);
+      debt.balance = clampToZero(debt.balance - extraPayment);
+      remainingBudget = clampToZero(remainingBudget - extraPayment);
+      const summary = debtSummaries.get(debt.id);
+      summary.totalPaid += extraPayment;
+      const paymentRecord = payments.find((record) => record.debtId === debt.id);
+      if (paymentRecord) {
+        paymentRecord.payment = clampToZero(paymentRecord.payment + extraPayment);
+        paymentRecord.balanceRemaining = debt.balance;
+      } else {
+        payments.push({
+          debtId: debt.id,
+          debtName: debt.name,
+          payment: clampToZero(extraPayment),
+          interestAccrued: clampToZero(interestMap.get(debt.id) || 0),
+          balanceRemaining: debt.balance,
+        });
+      }
+    }
+
+    const monthPaid = payments.reduce((sum, item) => sum + item.payment, 0);
+    totalPaid += monthPaid;
+    totalInterest += monthInterest;
+
+    activeDebts.forEach((debt) => {
+      const summary = debtSummaries.get(debt.id);
+      if (debt.balance <= 0.01 && summary.monthsToPayoff === null) {
+        summary.monthsToPayoff = monthIndex;
+        summary.payoffDate = formatISODate(currentDate);
+        debt.balance = 0;
+      }
+    });
+
+    const remainingBalance = activeDebts.reduce((sum, debt) => sum + debt.balance, 0);
+    schedule.push({
+      monthIndex,
+      date: formatISODate(currentDate),
+      totalInterest: clampToZero(monthInterest),
+      totalPaid: clampToZero(monthPaid),
+      remainingBalance: clampToZero(remainingBalance),
+      payments: payments.map((payment) => ({
+        ...payment,
+        payment: clampToZero(payment.payment),
+        interestAccrued: clampToZero(payment.interestAccrued),
+        balanceRemaining: clampToZero(payment.balanceRemaining),
+      })),
+    });
+  }
+
+  return {
+    strategy,
+    months: monthIndex,
+    totalInterest: clampToZero(totalInterest),
+    totalPaid: clampToZero(totalPaid),
+    payoffDate: schedule.length > 0 ? schedule[schedule.length - 1].date : formatISODate(start),
+    schedule,
+    debtSummaries: Array.from(debtSummaries.values()).map((summary) => ({
+      debtId: summary.debtId,
+      debtName: summary.debtName,
+      totalInterest: clampToZero(summary.totalInterest),
+      totalPaid: clampToZero(summary.totalPaid),
+      monthsToPayoff: summary.monthsToPayoff,
+      payoffDate: summary.payoffDate,
+      startingBalance: clampToZero(summary.startingBalance),
+    })),
+  };
+}
+
+module.exports = {
+  simulateStrategy,
+};

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,28 @@
+const http = require('node:http');
+const path = require('node:path');
+const config = require('./config');
+const Database = require('./storage/database');
+const Router = require('./http/router');
+const createStaticHandler = require('./http/static');
+const createServices = require('./services');
+const registerRoutes = require('./routes');
+
+function createServer() {
+  const db = new Database();
+  const baseContext = { config, db };
+  const services = createServices(baseContext);
+  const routerContext = { ...baseContext, services };
+  const router = new Router(routerContext);
+  registerRoutes(router, routerContext);
+  const serveStatic = createStaticHandler(path.join(__dirname, '..', 'frontend'));
+  return http.createServer((req, res) => {
+    if (serveStatic(req, res)) {
+      return;
+    }
+    router.handle(req, res);
+  });
+}
+
+module.exports = {
+  createServer,
+};

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,11 @@
+const DEFAULT_JWT_SECRET = 'change-this-secret-in-production';
+
+const config = {
+  port: Number(process.env.PORT || 4000),
+  jwtSecret: process.env.JWT_SECRET || DEFAULT_JWT_SECRET,
+  tokenExpiresInSeconds: Number(process.env.TOKEN_EXPIRES_IN || 60 * 60 * 12),
+  freeDebtLimit: Number(process.env.FREE_DEBT_LIMIT || 5),
+  reminderLookAheadDays: Number(process.env.REMINDER_LOOK_AHEAD_DAYS || 30),
+};
+
+module.exports = config;

--- a/src/errors/AppError.js
+++ b/src/errors/AppError.js
@@ -1,0 +1,10 @@
+class AppError extends Error {
+  constructor(statusCode, message, details = undefined) {
+    super(message);
+    this.name = 'AppError';
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+module.exports = AppError;

--- a/src/http/router.js
+++ b/src/http/router.js
@@ -1,0 +1,150 @@
+const { URL } = require('node:url');
+const AppError = require('../errors/AppError');
+const { sendJson, sendError } = require('../utils/response');
+
+function compilePath(path) {
+  const keys = [];
+  const pattern = path
+    .split('/')
+    .map((segment) => {
+      if (segment.startsWith(':')) {
+        keys.push(segment.slice(1));
+        return '([^/]+)';
+      }
+      return segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    })
+    .join('/');
+  const regex = new RegExp(`^${pattern}$`);
+  return { regex, keys };
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req
+      .on('data', (chunk) => {
+        chunks.push(chunk);
+        if (chunks.reduce((sum, part) => sum + part.length, 0) > 1e6) {
+          reject(new AppError(413, 'Request body is too large.'));
+        }
+      })
+      .on('end', () => {
+        if (chunks.length === 0) {
+          resolve({});
+          return;
+        }
+        try {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          if (!raw) {
+            resolve({});
+            return;
+          }
+          const parsed = JSON.parse(raw);
+          resolve(parsed);
+        } catch (error) {
+          reject(new AppError(400, 'Invalid JSON body.'));
+        }
+      })
+      .on('error', (error) => reject(error));
+  });
+}
+
+class Router {
+  constructor(context) {
+    this.context = context;
+    this.routes = [];
+  }
+
+  register(method, path, options, handler) {
+    let routeOptions = options;
+    let routeHandler = handler;
+    if (typeof options === 'function') {
+      routeHandler = options;
+      routeOptions = {};
+    }
+    const { regex, keys } = compilePath(path);
+    this.routes.push({
+      method: method.toUpperCase(),
+      path,
+      regex,
+      keys,
+      handler: routeHandler,
+      options: { auth: true, ...routeOptions },
+    });
+  }
+
+  get(path, options, handler) {
+    this.register('GET', path, options, handler);
+  }
+
+  post(path, options, handler) {
+    this.register('POST', path, options, handler);
+  }
+
+  patch(path, options, handler) {
+    this.register('PATCH', path, options, handler);
+  }
+
+  delete(path, options, handler) {
+    this.register('DELETE', path, options, handler);
+  }
+
+  async handle(req, res) {
+    try {
+      const method = req.method.toUpperCase();
+      if (method === 'OPTIONS') {
+        sendJson(res, 204);
+        return;
+      }
+      const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+      const path = url.pathname.replace(/\/$/, '') || '/';
+      const route = this.routes.find((item) => item.method === method && item.regex.test(path));
+      if (!route) {
+        sendJson(res, 404, { error: { message: 'Not Found' } });
+        return;
+      }
+      const match = path.match(route.regex);
+      const params = {};
+      if (match) {
+        route.keys.forEach((key, index) => {
+          params[key] = decodeURIComponent(match[index + 1]);
+        });
+      }
+      const query = Object.fromEntries(url.searchParams.entries());
+      let body = {};
+      if (['POST', 'PUT', 'PATCH'].includes(method)) {
+        body = await parseBody(req);
+      }
+      const requestContext = {
+        ...this.context,
+        req,
+        res,
+        params,
+        query,
+        body,
+        user: null,
+      };
+      if (route.options.auth) {
+        const authorization = req.headers.authorization || req.headers.Authorization;
+        const user = this.context.services.auth.authenticate(authorization);
+        requestContext.user = user;
+      }
+      const result = await route.handler(requestContext);
+      if (!res.writableEnded) {
+        if (result === undefined) {
+          sendJson(res, 204);
+          return;
+        }
+        if (typeof result === 'object' && result !== null && 'status' in result) {
+          sendJson(res, result.status, result.body);
+        } else {
+          sendJson(res, 200, result);
+        }
+      }
+    } catch (error) {
+      sendError(res, error instanceof Error ? error : new Error('Unexpected error'));
+    }
+  }
+}
+
+module.exports = Router;

--- a/src/http/static.js
+++ b/src/http/static.js
@@ -1,0 +1,75 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+};
+
+function createStaticHandler(rootDir) {
+  if (!rootDir) {
+    return () => false;
+  }
+  const absoluteRoot = path.resolve(rootDir);
+  if (!fs.existsSync(absoluteRoot)) {
+    return () => false;
+  }
+
+  return (req, res) => {
+    if (!['GET', 'HEAD'].includes(req.method)) {
+      return false;
+    }
+    const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    let pathname = decodeURIComponent(url.pathname);
+    if (pathname === '/' || pathname === '') {
+      pathname = '/index.html';
+    }
+    const normalizedPath = path.normalize(pathname).replace(/^\.\.(?:[\\/]|$)/, '');
+    const resolvedPath = path.join(absoluteRoot, normalizedPath);
+    if (!resolvedPath.startsWith(absoluteRoot)) {
+      return false;
+    }
+    let target = resolvedPath;
+    try {
+      const stats = fs.statSync(target);
+      if (stats.isDirectory()) {
+        target = path.join(target, 'index.html');
+      }
+      if (!fs.existsSync(target) || !fs.statSync(target).isFile()) {
+        return false;
+      }
+    } catch (error) {
+      return false;
+    }
+
+    const ext = path.extname(target).toLowerCase();
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.statusCode = 200;
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'no-store');
+
+    if (req.method === 'HEAD') {
+      res.end();
+      return true;
+    }
+
+    const stream = fs.createReadStream(target);
+    stream.on('error', () => {
+      if (!res.headersSent) {
+        res.statusCode = 500;
+      }
+      res.end();
+    });
+    stream.pipe(res);
+    return true;
+  };
+}
+
+module.exports = createStaticHandler;

--- a/src/routes/analyticsRoutes.js
+++ b/src/routes/analyticsRoutes.js
@@ -1,0 +1,20 @@
+function registerAnalyticsRoutes(router, context) {
+  const { services } = context;
+
+  router.get('/analytics/summary', async ({ user }) => {
+    const summary = services.analytics.getSummary(user.id);
+    return { status: 200, body: summary };
+  });
+
+  router.get('/analytics/distribution', async ({ user }) => {
+    const distribution = services.analytics.getDistribution(user.id);
+    return { status: 200, body: { distribution } };
+  });
+
+  router.get('/analytics/trends', async ({ user }) => {
+    const trends = services.analytics.getTrends(user.id);
+    return { status: 200, body: trends };
+  });
+}
+
+module.exports = registerAnalyticsRoutes;

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,0 +1,20 @@
+function registerAuthRoutes(router, context) {
+  const { services } = context;
+
+  router.post('/auth/register', { auth: false }, async ({ body }) => {
+    const result = services.auth.register(body || {});
+    return { status: 201, body: result };
+  });
+
+  router.post('/auth/login', { auth: false }, async ({ body }) => {
+    const result = services.auth.login(body || {});
+    return { status: 200, body: result };
+  });
+
+  router.post('/auth/forgot-password', { auth: false }, async ({ body }) => {
+    const result = services.auth.requestPasswordReset(body || {});
+    return { status: 200, body: result };
+  });
+}
+
+module.exports = registerAuthRoutes;

--- a/src/routes/debtRoutes.js
+++ b/src/routes/debtRoutes.js
@@ -1,0 +1,40 @@
+function registerDebtRoutes(router, context) {
+  const { services } = context;
+
+  router.post('/debts', async ({ user, body }) => {
+    const debt = services.debt.createDebt(user, body || {});
+    return { status: 201, body: { debt } };
+  });
+
+  router.get('/debts', async ({ user, query }) => {
+    const debts = services.debt.listDebts(user.id, query || {});
+    return { status: 200, body: { debts } };
+  });
+
+  router.get('/debts/:id', async ({ user, params }) => {
+    const debt = services.debt.getDebt(user.id, params.id);
+    return { status: 200, body: { debt } };
+  });
+
+  router.patch('/debts/:id', async ({ user, params, body }) => {
+    const debt = services.debt.updateDebt(user.id, params.id, body || {});
+    return { status: 200, body: { debt } };
+  });
+
+  router.delete('/debts/:id', async ({ user, params }) => {
+    const result = services.debt.deleteDebt(user.id, params.id);
+    return { status: 200, body: result };
+  });
+
+  router.post('/debts/:id/payments', async ({ user, params, body }) => {
+    const result = services.debt.recordPayment(user.id, params.id, body || {});
+    return { status: 201, body: result };
+  });
+
+  router.get('/debts/:id/payments', async ({ user, params }) => {
+    const payments = services.debt.listPayments(user.id, params.id);
+    return { status: 200, body: { payments } };
+  });
+}
+
+module.exports = registerDebtRoutes;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,17 @@
+const registerAuthRoutes = require('./authRoutes');
+const registerUserRoutes = require('./userRoutes');
+const registerDebtRoutes = require('./debtRoutes');
+const registerStrategyRoutes = require('./strategyRoutes');
+const registerAnalyticsRoutes = require('./analyticsRoutes');
+const registerReminderRoutes = require('./reminderRoutes');
+
+function registerRoutes(router, context) {
+  registerAuthRoutes(router, context);
+  registerUserRoutes(router, context);
+  registerDebtRoutes(router, context);
+  registerStrategyRoutes(router, context);
+  registerAnalyticsRoutes(router, context);
+  registerReminderRoutes(router, context);
+}
+
+module.exports = registerRoutes;

--- a/src/routes/reminderRoutes.js
+++ b/src/routes/reminderRoutes.js
@@ -1,0 +1,20 @@
+function registerReminderRoutes(router, context) {
+  const { services } = context;
+
+  router.get('/reminders/upcoming', async ({ user }) => {
+    const reminders = services.reminder.getUpcomingReminders(user);
+    return { status: 200, body: { reminders } };
+  });
+
+  router.get('/reminders', async ({ user }) => {
+    const reminders = services.reminder.listCustomReminders(user.id);
+    return { status: 200, body: { reminders } };
+  });
+
+  router.post('/reminders', async ({ user, body }) => {
+    const reminder = services.reminder.createCustomReminder(user.id, body || {});
+    return { status: 201, body: { reminder } };
+  });
+}
+
+module.exports = registerReminderRoutes;

--- a/src/routes/strategyRoutes.js
+++ b/src/routes/strategyRoutes.js
@@ -1,0 +1,15 @@
+function registerStrategyRoutes(router, context) {
+  const { services } = context;
+
+  router.post('/strategies/simulate', async ({ user, body }) => {
+    const result = services.strategy.simulate(user.id, body || {});
+    return { status: 200, body: result };
+  });
+
+  router.post('/strategies/compare', async ({ user, body }) => {
+    const result = services.strategy.compare(user.id, body || {});
+    return { status: 200, body: result };
+  });
+}
+
+module.exports = registerStrategyRoutes;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,0 +1,21 @@
+function registerUserRoutes(router, context) {
+  const { services } = context;
+
+  router.get('/users/me', async ({ user }) => {
+    const profile = services.user.getProfile(user.id);
+    return { status: 200, body: { user: profile } };
+  });
+
+  router.patch('/users/me', async ({ user, body }) => {
+    const updated = services.user.updateProfile(user.id, body || {});
+    return { status: 200, body: { user: updated } };
+  });
+
+  router.patch('/users/membership', async ({ user, body }) => {
+    const membership = (body && body.membership) || 'free';
+    const updated = services.user.updateMembership(user.id, membership);
+    return { status: 200, body: { user: updated } };
+  });
+}
+
+module.exports = registerUserRoutes;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,8 @@
+const config = require('./config');
+const { createServer } = require('./app');
+
+const server = createServer();
+
+server.listen(config.port, () => {
+  console.log(`DebtWise AI API listening on port ${config.port}`);
+});

--- a/src/services/analyticsService.js
+++ b/src/services/analyticsService.js
@@ -1,0 +1,87 @@
+const { clampToZero, formatYearMonth } = require('../utils/date');
+
+function createAnalyticsService(context) {
+  const { db } = context;
+
+  function getSummary(userId) {
+    const debts = db.data.debts.filter((debt) => debt.userId === userId);
+    const totalPrincipal = debts.reduce((sum, debt) => sum + (debt.principal || 0), 0);
+    const totalBalance = debts.reduce((sum, debt) => sum + (debt.balance || 0), 0);
+    const totalPaid = debts.reduce((sum, debt) => sum + (debt.totalPaid || 0), 0);
+    const progress = totalPrincipal > 0 ? clampToZero(((totalPrincipal - totalBalance) / totalPrincipal) * 100) : 0;
+    const nextDueDebt = debts
+      .filter((debt) => debt.balance > 0)
+      .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))[0];
+    const averageApr = debts.length > 0 ? clampToZero(debts.reduce((sum, debt) => sum + debt.apr, 0) / debts.length) : 0;
+
+    return {
+      totals: {
+        principal: clampToZero(totalPrincipal),
+        balance: clampToZero(totalBalance),
+        paid: clampToZero(totalPaid),
+        averageApr,
+      },
+      progress,
+      nextDueDebt: nextDueDebt
+        ? {
+            id: nextDueDebt.id,
+            name: nextDueDebt.name,
+            dueDate: nextDueDebt.dueDate,
+            balance: clampToZero(nextDueDebt.balance),
+          }
+        : null,
+      debtsCount: debts.length,
+    };
+  }
+
+  function getDistribution(userId) {
+    const debts = db.data.debts.filter((debt) => debt.userId === userId);
+    const grouped = debts.reduce((acc, debt) => {
+      const key = debt.type || 'other';
+      if (!acc[key]) {
+        acc[key] = { type: key, principal: 0, balance: 0 };
+      }
+      acc[key].principal += debt.principal || 0;
+      acc[key].balance += debt.balance || 0;
+      return acc;
+    }, {});
+    return Object.values(grouped).map((item) => ({
+      type: item.type,
+      principal: clampToZero(item.principal),
+      balance: clampToZero(item.balance),
+    }));
+  }
+
+  function getTrends(userId) {
+    const payments = db.data.payments.filter((payment) => payment.userId === userId);
+    const grouped = payments.reduce((acc, payment) => {
+      const key = formatYearMonth(payment.paidAt);
+      if (!acc[key]) {
+        acc[key] = { month: key, paid: 0, payments: 0 };
+      }
+      acc[key].paid += payment.amount;
+      acc[key].payments += 1;
+      return acc;
+    }, {});
+    const series = Object.values(grouped)
+      .map((item) => ({
+        month: item.month,
+        paid: clampToZero(item.paid),
+        payments: item.payments,
+      }))
+      .sort((a, b) => (a.month > b.month ? 1 : -1));
+    return {
+      months: series.map((item) => item.month),
+      paid: series.map((item) => item.paid),
+      payments: series.map((item) => item.payments),
+    };
+  }
+
+  return {
+    getSummary,
+    getDistribution,
+    getTrends,
+  };
+}
+
+module.exports = createAnalyticsService;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,103 @@
+const crypto = require('node:crypto');
+const AppError = require('../errors/AppError');
+const { hashPassword, verifyPassword } = require('../utils/password');
+const { getString, ensureEmail } = require('../utils/validators');
+const { sign, verify } = require('../utils/jwt');
+const { sanitizeUser } = require('../utils/serializers');
+
+function createAuthService(context) {
+  const { db, config } = context;
+
+  function generateToken(user) {
+    return sign({ sub: user.id, membership: user.membership }, config.jwtSecret, {
+      expiresIn: config.tokenExpiresInSeconds,
+    });
+  }
+
+  function register(payload) {
+    const email = ensureEmail(getString(payload, 'email', { minLength: 3 }));
+    const password = getString(payload, 'password', { minLength: 8 });
+    const name = getString(payload, 'name', { required: false, defaultValue: '' });
+
+    const existing = db.data.users.find((user) => user.email === email);
+    if (existing) {
+      throw new AppError(409, 'Email is already registered.');
+    }
+
+    const now = new Date().toISOString();
+    const user = {
+      id: crypto.randomUUID(),
+      email,
+      passwordHash: hashPassword(password),
+      name,
+      income: Number(payload.income) || 0,
+      expenses: Number(payload.expenses) || 0,
+      reminderPreferences: {
+        daysBeforeDue: Number(payload.reminderDays || 3),
+        timeOfDay: payload.reminderTime || '09:00',
+      },
+      membership: 'free',
+      createdAt: now,
+      updatedAt: now,
+    };
+    db.data.users.push(user);
+    db.write();
+
+    const token = generateToken(user);
+    return {
+      token,
+      user: sanitizeUser(user),
+    };
+  }
+
+  function login(payload) {
+    const email = ensureEmail(getString(payload, 'email', { minLength: 3 }));
+    const password = getString(payload, 'password', { minLength: 8 });
+    const user = db.data.users.find((record) => record.email === email);
+    if (!user || !verifyPassword(password, user.passwordHash)) {
+      throw new AppError(401, 'Invalid email or password.');
+    }
+    const token = generateToken(user);
+    return {
+      token,
+      user: sanitizeUser(user),
+    };
+  }
+
+  function authenticate(authorizationHeader) {
+    if (!authorizationHeader || !authorizationHeader.startsWith('Bearer ')) {
+      throw new AppError(401, 'Authentication token is missing.');
+    }
+    const token = authorizationHeader.slice('Bearer '.length);
+    const payload = verify(token, config.jwtSecret);
+    const user = db.data.users.find((record) => record.id === payload.sub);
+    if (!user) {
+      throw new AppError(401, 'User not found for provided token.');
+    }
+    return sanitizeUser(user);
+  }
+
+  function requestPasswordReset(payload) {
+    const email = ensureEmail(getString(payload, 'email', { minLength: 3 }));
+    const user = db.data.users.find((record) => record.email === email);
+    if (!user) {
+      throw new AppError(404, 'User with provided email was not found.');
+    }
+    const token = sign({ sub: user.id, purpose: 'password-reset' }, config.jwtSecret, {
+      expiresIn: 60 * 15,
+    });
+    return {
+      resetToken: token,
+      message: 'Password reset token generated. Use this token to authorize password reset flow.',
+    };
+  }
+
+  return {
+    register,
+    login,
+    authenticate,
+    requestPasswordReset,
+  };
+}
+
+module.exports = createAuthService;

--- a/src/services/debtService.js
+++ b/src/services/debtService.js
@@ -1,0 +1,195 @@
+const crypto = require('node:crypto');
+const AppError = require('../errors/AppError');
+const { getString, getNumber, getDate } = require('../utils/validators');
+const { clampToZero } = require('../utils/date');
+
+const SUPPORTED_TYPES = ['credit_card', 'loan', 'mortgage', 'auto', 'student', 'other'];
+
+function normalizeType(value) {
+  const normalized = value.toLowerCase().replace(/\s+/g, '_');
+  if (SUPPORTED_TYPES.includes(normalized)) {
+    return normalized;
+  }
+  return 'other';
+}
+
+function createDebtService(context) {
+  const { db, config } = context;
+
+  function formatDebt(debt) {
+    const totalPaid = clampToZero(debt.totalPaid || 0);
+    const progress = debt.principal > 0 ? clampToZero(((debt.principal - debt.balance) / debt.principal) * 100) : 0;
+    let status = 'active';
+    if (debt.balance <= 0.01) {
+      status = 'paid';
+    } else if (new Date(debt.dueDate) < new Date()) {
+      status = 'overdue';
+    }
+    return {
+      id: debt.id,
+      userId: debt.userId,
+      name: debt.name,
+      principal: clampToZero(debt.principal),
+      apr: debt.apr,
+      minimumPayment: clampToZero(debt.minimumPayment),
+      dueDate: debt.dueDate,
+      type: debt.type,
+      balance: clampToZero(debt.balance),
+      totalPaid,
+      progress,
+      status,
+      createdAt: debt.createdAt,
+      updatedAt: debt.updatedAt,
+      lastPaymentAt: debt.lastPaymentAt || null,
+    };
+  }
+
+  function ensureDebt(userId, debtId) {
+    const debt = db.data.debts.find((record) => record.id === debtId && record.userId === userId);
+    if (!debt) {
+      throw new AppError(404, 'Debt not found.');
+    }
+    return debt;
+  }
+
+  function createDebt(user, payload) {
+    if (user.membership !== 'premium') {
+      const count = db.data.debts.filter((debt) => debt.userId === user.id).length;
+      if (count >= config.freeDebtLimit) {
+        throw new AppError(403, `Free membership allows up to ${config.freeDebtLimit} debts.`);
+      }
+    }
+    const name = getString(payload, 'name', { minLength: 1 });
+    const principal = getNumber(payload, 'principal', { min: 0.01 });
+    const apr = getNumber(payload, 'apr', { min: 0 });
+    const minimumPayment = getNumber(payload, 'minimumPayment', { min: 0.01 });
+    const dueDate = getDate(payload, 'dueDate');
+    const type = payload.type ? normalizeType(String(payload.type)) : 'other';
+    const now = new Date().toISOString();
+    const debt = {
+      id: crypto.randomUUID(),
+      userId: user.id,
+      name,
+      principal: clampToZero(principal),
+      apr,
+      minimumPayment: clampToZero(minimumPayment),
+      dueDate: dueDate.toISOString(),
+      type,
+      balance: clampToZero(principal),
+      totalPaid: 0,
+      createdAt: now,
+      updatedAt: now,
+      lastPaymentAt: null,
+    };
+    db.data.debts.push(debt);
+    db.write();
+    return formatDebt(debt);
+  }
+
+  function listDebts(userId, query = {}) {
+    let results = db.data.debts.filter((debt) => debt.userId === userId);
+    if (query.type) {
+      const requested = normalizeType(String(query.type));
+      results = results.filter((debt) => debt.type === requested);
+    }
+    if (query.status === 'active') {
+      results = results.filter((debt) => debt.balance > 0.01);
+    }
+    if (query.status === 'paid') {
+      results = results.filter((debt) => debt.balance <= 0.01);
+    }
+    if (query.sort === 'balance') {
+      results.sort((a, b) => a.balance - b.balance);
+    } else if (query.sort === 'apr') {
+      results.sort((a, b) => b.apr - a.apr);
+    } else if (query.sort === 'dueDate') {
+      results.sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate));
+    } else {
+      results.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+    }
+    return results.map((debt) => formatDebt(debt));
+  }
+
+  function getDebt(userId, debtId) {
+    return formatDebt(ensureDebt(userId, debtId));
+  }
+
+  function updateDebt(userId, debtId, payload) {
+    const debt = ensureDebt(userId, debtId);
+    if (payload.name !== undefined) {
+      debt.name = getString(payload, 'name', { required: false, defaultValue: debt.name });
+    }
+    if (payload.apr !== undefined) {
+      debt.apr = getNumber(payload, 'apr', { required: false, min: 0, defaultValue: debt.apr });
+    }
+    if (payload.minimumPayment !== undefined) {
+      debt.minimumPayment = clampToZero(getNumber(payload, 'minimumPayment', { required: false, min: 0.01, defaultValue: debt.minimumPayment }));
+    }
+    if (payload.dueDate !== undefined) {
+      debt.dueDate = getDate(payload, 'dueDate', { required: false, defaultValue: new Date(debt.dueDate) }).toISOString();
+    }
+    if (payload.type !== undefined) {
+      debt.type = normalizeType(String(payload.type));
+    }
+    debt.updatedAt = new Date().toISOString();
+    db.write();
+    return formatDebt(debt);
+  }
+
+  function deleteDebt(userId, debtId) {
+    const debt = ensureDebt(userId, debtId);
+    db.data.debts = db.data.debts.filter((record) => record.id !== debtId);
+    db.data.payments = db.data.payments.filter((payment) => payment.debtId !== debtId);
+    db.write();
+    return { success: true };
+  }
+
+  function recordPayment(userId, debtId, payload) {
+    const debt = ensureDebt(userId, debtId);
+    const amount = getNumber(payload, 'amount', { min: 0.01 });
+    const paidAt = payload.paidAt ? getDate(payload, 'paidAt', { required: false, defaultValue: new Date() }) : new Date();
+    const note = payload.note ? getString(payload, 'note', { required: false, defaultValue: '' }) : '';
+
+    const payment = {
+      id: crypto.randomUUID(),
+      userId,
+      debtId,
+      amount: clampToZero(amount),
+      paidAt: paidAt.toISOString(),
+      createdAt: new Date().toISOString(),
+      note,
+    };
+    db.data.payments.push(payment);
+    debt.balance = clampToZero(debt.balance - amount);
+    debt.totalPaid = clampToZero((debt.totalPaid || 0) + amount);
+    debt.lastPaymentAt = payment.paidAt;
+    debt.updatedAt = new Date().toISOString();
+    if (debt.balance <= 0.01) {
+      debt.balance = 0;
+    }
+    db.write();
+    return {
+      payment,
+      debt: formatDebt(debt),
+    };
+  }
+
+  function listPayments(userId, debtId) {
+    ensureDebt(userId, debtId);
+    return db.data.payments
+      .filter((payment) => payment.userId === userId && payment.debtId === debtId)
+      .sort((a, b) => new Date(b.paidAt) - new Date(a.paidAt));
+  }
+
+  return {
+    createDebt,
+    listDebts,
+    getDebt,
+    updateDebt,
+    deleteDebt,
+    recordPayment,
+    listPayments,
+  };
+}
+
+module.exports = createDebtService;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,26 @@
+const createAuthService = require('./authService');
+const createUserService = require('./userService');
+const createDebtService = require('./debtService');
+const createStrategyService = require('./strategyService');
+const createAnalyticsService = require('./analyticsService');
+const createReminderService = require('./reminderService');
+
+function createServices(context) {
+  const userService = createUserService(context);
+  const services = {
+    auth: null,
+    user: userService,
+    debt: null,
+    strategy: null,
+    analytics: null,
+    reminder: null,
+  };
+  services.auth = createAuthService({ ...context, services });
+  services.debt = createDebtService({ ...context, services });
+  services.strategy = createStrategyService({ ...context, services });
+  services.analytics = createAnalyticsService({ ...context, services });
+  services.reminder = createReminderService({ ...context, services });
+  return services;
+}
+
+module.exports = createServices;

--- a/src/services/reminderService.js
+++ b/src/services/reminderService.js
@@ -1,0 +1,104 @@
+const crypto = require('node:crypto');
+const AppError = require('../errors/AppError');
+const { getString, getDate } = require('../utils/validators');
+
+function applyTimeOfDay(date, timeString) {
+  if (!timeString || typeof timeString !== 'string') {
+    return date;
+  }
+  const [hours, minutes] = timeString.split(':').map((value) => Number(value));
+  if (Number.isInteger(hours) && Number.isInteger(minutes)) {
+    const updated = new Date(date);
+    updated.setHours(hours, minutes, 0, 0);
+    return updated;
+  }
+  return date;
+}
+
+function createReminderService(context) {
+  const { db, config } = context;
+
+  function listCustomReminders(userId) {
+    return db.data.reminders
+      .filter((reminder) => reminder.userId === userId)
+      .sort((a, b) => new Date(a.notifyAt) - new Date(b.notifyAt));
+  }
+
+  function ensureDebt(userId, debtId) {
+    const debt = db.data.debts.find((record) => record.id === debtId && record.userId === userId);
+    if (!debt) {
+      throw new AppError(404, 'Debt not found for reminder.');
+    }
+    return debt;
+  }
+
+  function createCustomReminder(userId, payload) {
+    const title = getString(payload, 'title', { minLength: 1 });
+    const notifyAt = getDate(payload, 'notifyAt').toISOString();
+    let debtId = null;
+    if (payload.debtId) {
+      ensureDebt(userId, payload.debtId);
+      debtId = payload.debtId;
+    }
+    const reminder = {
+      id: crypto.randomUUID(),
+      userId,
+      debtId,
+      title,
+      notifyAt,
+      createdAt: new Date().toISOString(),
+    };
+    db.data.reminders.push(reminder);
+    db.write();
+    return reminder;
+  }
+
+  function getUpcomingReminders(user) {
+    const now = new Date();
+    const future = new Date();
+    future.setDate(future.getDate() + config.reminderLookAheadDays);
+    const reminders = [];
+    const preferences = user.reminderPreferences || { daysBeforeDue: 3, timeOfDay: '09:00' };
+
+    db.data.debts
+      .filter((debt) => debt.userId === user.id && debt.balance > 0)
+      .forEach((debt) => {
+        const dueDate = new Date(debt.dueDate);
+        const reminderDate = new Date(dueDate);
+        reminderDate.setDate(reminderDate.getDate() - (preferences.daysBeforeDue || 0));
+        const notifyAt = applyTimeOfDay(reminderDate, preferences.timeOfDay);
+        if (notifyAt >= now && notifyAt <= future) {
+          reminders.push({
+            id: `${debt.id}-due`,
+            title: `Upcoming payment: ${debt.name}`,
+            debtId: debt.id,
+            notifyAt: notifyAt.toISOString(),
+            dueDate: debt.dueDate,
+            amountDue: debt.minimumPayment,
+            type: 'system',
+          });
+        }
+      });
+
+    listCustomReminders(user.id).forEach((reminder) => {
+      const notifyAt = new Date(reminder.notifyAt);
+      if (notifyAt >= now && notifyAt <= future) {
+        reminders.push({
+          ...reminder,
+          type: 'custom',
+        });
+      }
+    });
+
+    reminders.sort((a, b) => new Date(a.notifyAt) - new Date(b.notifyAt));
+    return reminders;
+  }
+
+  return {
+    listCustomReminders,
+    createCustomReminder,
+    getUpcomingReminders,
+  };
+}
+
+module.exports = createReminderService;

--- a/src/services/strategyService.js
+++ b/src/services/strategyService.js
@@ -1,0 +1,54 @@
+const AppError = require('../errors/AppError');
+const { getNumber, getString } = require('../utils/validators');
+const { simulateStrategy } = require('../algorithms/debtStrategies');
+
+function createStrategyService(context) {
+  const { db } = context;
+
+  function getActiveDebts(userId) {
+    const debts = db.data.debts.filter((debt) => debt.userId === userId && debt.balance > 0);
+    if (debts.length === 0) {
+      throw new AppError(400, 'No active debts found for simulation.');
+    }
+    return debts;
+  }
+
+  function simulate(userId, payload) {
+    const strategy = getString(payload, 'strategy', { minLength: 3 }).toLowerCase();
+    const monthlyBudget = getNumber(payload, 'monthlyBudget', { min: 0.01 });
+    const startDate = payload.startDate ? new Date(payload.startDate) : new Date();
+    const debts = getActiveDebts(userId);
+    const result = simulateStrategy(debts, { strategy, monthlyBudget, startDate });
+    return {
+      strategy: result.strategy,
+      monthlyBudget,
+      totalInterest: result.totalInterest,
+      months: result.months,
+      payoffDate: result.payoffDate,
+      debtSummaries: result.debtSummaries,
+      schedule: result.schedule,
+    };
+  }
+
+  function compare(userId, payload) {
+    const monthlyBudget = getNumber(payload, 'monthlyBudget', { min: 0.01 });
+    const startDate = payload.startDate ? new Date(payload.startDate) : new Date();
+    const debts = getActiveDebts(userId);
+    const snowball = simulateStrategy(debts, { strategy: 'snowball', monthlyBudget, startDate });
+    const avalanche = simulateStrategy(debts, { strategy: 'avalanche', monthlyBudget, startDate });
+    return {
+      monthlyBudget,
+      snowball,
+      avalanche,
+      interestSavings: Number((snowball.totalInterest - avalanche.totalInterest).toFixed(2)),
+      monthsDifference: snowball.months - avalanche.months,
+    };
+  }
+
+  return {
+    simulate,
+    compare,
+  };
+}
+
+module.exports = createStrategyService;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,62 @@
+const AppError = require('../errors/AppError');
+const { getString, getNumber } = require('../utils/validators');
+const { sanitizeUser } = require('../utils/serializers');
+
+function createUserService(context) {
+  const { db } = context;
+
+  function getById(userId) {
+    const user = db.data.users.find((record) => record.id === userId);
+    if (!user) {
+      throw new AppError(404, 'User not found.');
+    }
+    return user;
+  }
+
+  function getProfile(userId) {
+    return sanitizeUser(getById(userId));
+  }
+
+  function updateProfile(userId, payload) {
+    const user = getById(userId);
+    if (payload.name !== undefined) {
+      user.name = getString(payload, 'name', { required: false, defaultValue: user.name });
+    }
+    if (payload.income !== undefined) {
+      user.income = getNumber(payload, 'income', { required: false, min: 0, defaultValue: user.income });
+    }
+    if (payload.expenses !== undefined) {
+      user.expenses = getNumber(payload, 'expenses', { required: false, min: 0, defaultValue: user.expenses });
+    }
+    if (payload.reminderPreferences) {
+      const prefs = payload.reminderPreferences;
+      user.reminderPreferences = {
+        daysBeforeDue: getNumber(prefs, 'daysBeforeDue', { required: false, min: 0, defaultValue: user.reminderPreferences.daysBeforeDue }),
+        timeOfDay: getString(prefs, 'timeOfDay', { required: false, defaultValue: user.reminderPreferences.timeOfDay }),
+      };
+    }
+    user.updatedAt = new Date().toISOString();
+    db.write();
+    return sanitizeUser(user);
+  }
+
+  function updateMembership(userId, membership) {
+    const user = getById(userId);
+    if (!['free', 'premium'].includes(membership)) {
+      throw new AppError(400, 'Membership must be either free or premium.');
+    }
+    user.membership = membership;
+    user.updatedAt = new Date().toISOString();
+    db.write();
+    return sanitizeUser(user);
+  }
+
+  return {
+    getProfile,
+    updateProfile,
+    updateMembership,
+    getById,
+  };
+}
+
+module.exports = createUserService;

--- a/src/storage/database.js
+++ b/src/storage/database.js
@@ -1,0 +1,43 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_DATA = {
+  users: [],
+  debts: [],
+  payments: [],
+  reminders: [],
+};
+
+class Database {
+  constructor(filePath = path.join(process.cwd(), 'data', 'db.json')) {
+    this.filePath = filePath;
+    this.ensureStorage();
+    this.data = this.read();
+  }
+
+  ensureStorage() {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    if (!fs.existsSync(this.filePath)) {
+      fs.writeFileSync(this.filePath, JSON.stringify(DEFAULT_DATA, null, 2));
+    }
+  }
+
+  read() {
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw);
+      return { ...DEFAULT_DATA, ...parsed };
+    } catch (error) {
+      return { ...DEFAULT_DATA };
+    }
+  }
+
+  write() {
+    fs.writeFileSync(this.filePath, JSON.stringify(this.data, null, 2));
+  }
+}
+
+module.exports = Database;

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,46 @@
+function formatISODate(date) {
+  return new Date(date).toISOString();
+}
+
+function addMonths(date, months) {
+  const result = new Date(date);
+  const d = result.getDate();
+  result.setMonth(result.getMonth() + months);
+  if (result.getDate() !== d) {
+    result.setDate(0);
+  }
+  return result;
+}
+
+function startOfMonth(date) {
+  const result = new Date(date);
+  result.setDate(1);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+function formatYearMonth(date) {
+  const d = new Date(date);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function differenceInDays(later, earlier) {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.round((later.getTime() - earlier.getTime()) / msPerDay);
+}
+
+function clampToZero(value) {
+  if (Math.abs(value) < 0.005) {
+    return 0;
+  }
+  return Number(value.toFixed(2));
+}
+
+module.exports = {
+  formatISODate,
+  addMonths,
+  startOfMonth,
+  formatYearMonth,
+  differenceInDays,
+  clampToZero,
+};

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,64 @@
+const crypto = require('node:crypto');
+const AppError = require('../errors/AppError');
+
+function base64UrlEncode(input) {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function base64UrlDecode(input) {
+  const pad = input.length % 4;
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/') + (pad ? '='.repeat(4 - pad) : '');
+  return Buffer.from(normalized, 'base64').toString();
+}
+
+function sign(payload, secret, options = {}) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const now = Math.floor(Date.now() / 1000);
+  const fullPayload = { ...payload, iat: now };
+  if (options.expiresIn) {
+    fullPayload.exp = now + Number(options.expiresIn);
+  }
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(fullPayload));
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+function verify(token, secret) {
+  if (typeof token !== 'string' || token.split('.').length !== 3) {
+    throw new AppError(401, 'Invalid authentication token.');
+  }
+  const [headerSegment, payloadSegment, signatureSegment] = token.split('.');
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(`${headerSegment}.${payloadSegment}`)
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+  if (!crypto.timingSafeEqual(Buffer.from(signatureSegment), Buffer.from(expectedSignature))) {
+    throw new AppError(401, 'Invalid authentication token.');
+  }
+  const payload = JSON.parse(base64UrlDecode(payloadSegment));
+  if (payload.exp && Math.floor(Date.now() / 1000) > payload.exp) {
+    throw new AppError(401, 'Authentication token has expired.');
+  }
+  return payload;
+}
+
+module.exports = {
+  sign,
+  verify,
+};

--- a/src/utils/password.js
+++ b/src/utils/password.js
@@ -1,0 +1,41 @@
+const crypto = require('node:crypto');
+
+const ITERATIONS = 120_000;
+const KEY_LENGTH = 64;
+const DIGEST = 'sha512';
+
+function hashPassword(password) {
+  if (typeof password !== 'string' || password.length < 8) {
+    throw new Error('Password must be at least 8 characters long.');
+  }
+  const salt = crypto.randomBytes(16).toString('hex');
+  const hash = crypto
+    .pbkdf2Sync(password, salt, ITERATIONS, KEY_LENGTH, DIGEST)
+    .toString('hex');
+  return `${salt}:${hash}`;
+}
+
+function verifyPassword(password, stored) {
+  if (!stored) {
+    return false;
+  }
+  const [salt, originalHash] = stored.split(':');
+  if (!salt || !originalHash) {
+    return false;
+  }
+  const hash = crypto
+    .pbkdf2Sync(password, salt, ITERATIONS, KEY_LENGTH, DIGEST)
+    .toString('hex');
+
+  const originalBuffer = Buffer.from(originalHash, 'hex');
+  const hashBuffer = Buffer.from(hash, 'hex');
+  if (originalBuffer.length !== hashBuffer.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(originalBuffer, hashBuffer);
+}
+
+module.exports = {
+  hashPassword,
+  verifyPassword,
+};

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -1,0 +1,32 @@
+function sendJson(res, statusCode, payload) {
+  const data = payload === undefined ? null : payload;
+  const body = data === null ? '' : JSON.stringify(data);
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,PUT,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (body.length > 0) {
+    res.end(body);
+  } else {
+    res.end();
+  }
+}
+
+function sendError(res, error) {
+  const status = error.statusCode || 500;
+  const payload = {
+    error: {
+      message: error.message || 'Unexpected error occurred.',
+    },
+  };
+  if (error.details) {
+    payload.error.details = error.details;
+  }
+  sendJson(res, status, payload);
+}
+
+module.exports = {
+  sendJson,
+  sendError,
+};

--- a/src/utils/serializers.js
+++ b/src/utils/serializers.js
@@ -1,0 +1,8 @@
+function sanitizeUser(user) {
+  const { passwordHash, ...publicUser } = user;
+  return publicUser;
+}
+
+module.exports = {
+  sanitizeUser,
+};

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,0 +1,95 @@
+const AppError = require('../errors/AppError');
+
+function getString(data, field, options = {}) {
+  const { required = true, minLength = 0, maxLength = Infinity, pattern, transform = (v) => v.trim(), defaultValue = null } = options;
+  const raw = data[field];
+  if (raw === undefined || raw === null) {
+    if (required) {
+      throw new AppError(400, `${field} is required.`);
+    }
+    return defaultValue;
+  }
+  if (typeof raw !== 'string') {
+    throw new AppError(400, `${field} must be a string.`);
+  }
+  const value = transform(raw);
+  if (value.length < minLength) {
+    throw new AppError(400, `${field} must be at least ${minLength} characters.`);
+  }
+  if (value.length > maxLength) {
+    throw new AppError(400, `${field} must be at most ${maxLength} characters.`);
+  }
+  if (pattern && !pattern.test(value)) {
+    throw new AppError(400, `${field} has an invalid format.`);
+  }
+  return value;
+}
+
+function getNumber(data, field, options = {}) {
+  const { required = true, min = -Infinity, max = Infinity, defaultValue = null } = options;
+  const raw = data[field];
+  if (raw === undefined || raw === null || raw === '') {
+    if (required) {
+      throw new AppError(400, `${field} is required.`);
+    }
+    return defaultValue;
+  }
+  const value = Number(raw);
+  if (Number.isNaN(value)) {
+    throw new AppError(400, `${field} must be a number.`);
+  }
+  if (value < min) {
+    throw new AppError(400, `${field} must be greater than or equal to ${min}.`);
+  }
+  if (value > max) {
+    throw new AppError(400, `${field} must be less than or equal to ${max}.`);
+  }
+  return value;
+}
+
+function getDate(data, field, options = {}) {
+  const { required = true, defaultValue = null } = options;
+  const raw = data[field];
+  if (raw === undefined || raw === null || raw === '') {
+    if (required) {
+      throw new AppError(400, `${field} is required.`);
+    }
+    return defaultValue;
+  }
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    throw new AppError(400, `${field} must be a valid date.`);
+  }
+  return date;
+}
+
+function getEnum(data, field, values, options = {}) {
+  const { required = true, defaultValue = null } = options;
+  const raw = data[field];
+  if (raw === undefined || raw === null || raw === '') {
+    if (required) {
+      throw new AppError(400, `${field} is required.`);
+    }
+    return defaultValue;
+  }
+  if (!values.includes(raw)) {
+    throw new AppError(400, `${field} must be one of: ${values.join(', ')}.`);
+  }
+  return raw;
+}
+
+function ensureEmail(value, field = 'email') {
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailPattern.test(value)) {
+    throw new AppError(400, `${field} must be a valid email address.`);
+  }
+  return value.toLowerCase();
+}
+
+module.exports = {
+  getString,
+  getNumber,
+  getDate,
+  getEnum,
+  ensureEmail,
+};

--- a/tests/strategy.test.js
+++ b/tests/strategy.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { simulateStrategy } = require('../src/algorithms/debtStrategies');
+const AppError = require('../src/errors/AppError');
+
+const sampleDebts = [
+  {
+    id: 'debt-1',
+    name: 'Credit Card',
+    balance: 1500,
+    apr: 18,
+    minimumPayment: 50,
+  },
+  {
+    id: 'debt-2',
+    name: 'Student Loan',
+    balance: 6000,
+    apr: 4.5,
+    minimumPayment: 120,
+  },
+  {
+    id: 'debt-3',
+    name: 'Auto Loan',
+    balance: 3200,
+    apr: 7.9,
+    minimumPayment: 90,
+  },
+];
+
+test('snowball strategy prioritises the smallest balances first', () => {
+  const result = simulateStrategy(sampleDebts, { strategy: 'snowball', monthlyBudget: 700, startDate: new Date('2024-01-01') });
+  const creditCard = result.debtSummaries.find((item) => item.debtId === 'debt-1');
+  const autoLoan = result.debtSummaries.find((item) => item.debtId === 'debt-3');
+  const studentLoan = result.debtSummaries.find((item) => item.debtId === 'debt-2');
+  assert.ok(
+    creditCard.monthsToPayoff <= autoLoan.monthsToPayoff,
+    'Credit card (smallest balance) should not take longer than auto loan'
+  );
+  assert.ok(
+    autoLoan.monthsToPayoff <= studentLoan.monthsToPayoff,
+    'Auto loan should be paid off before or alongside the larger student loan'
+  );
+  assert.equal(result.strategy, 'snowball');
+  assert.equal(result.schedule[0].date.startsWith('2024-01'), true);
+});
+
+test('avalanche strategy prioritises the highest APR balances', () => {
+  const snowball = simulateStrategy(sampleDebts, { strategy: 'snowball', monthlyBudget: 700, startDate: new Date('2024-01-01') });
+  const avalanche = simulateStrategy(sampleDebts, { strategy: 'avalanche', monthlyBudget: 700, startDate: new Date('2024-01-01') });
+
+  const creditCardAvalanche = avalanche.debtSummaries.find((item) => item.debtId === 'debt-1');
+  const autoLoanAvalanche = avalanche.debtSummaries.find((item) => item.debtId === 'debt-3');
+  const studentLoanAvalanche = avalanche.debtSummaries.find((item) => item.debtId === 'debt-2');
+
+  assert.ok(
+    creditCardAvalanche.monthsToPayoff <= autoLoanAvalanche.monthsToPayoff,
+    'Highest APR debt should not take longer than lower APR debts'
+  );
+  assert.ok(
+    autoLoanAvalanche.monthsToPayoff <= studentLoanAvalanche.monthsToPayoff,
+    'Next highest APR should be resolved before or alongside lower APR debts'
+  );
+  assert.ok(
+    avalanche.totalInterest <= snowball.totalInterest,
+    'Avalanche should not accrue more interest than snowball for the same inputs'
+  );
+});
+
+test('simulation throws when monthly budget cannot cover minimums', () => {
+  assert.throws(
+    () => simulateStrategy(sampleDebts, { strategy: 'snowball', monthlyBudget: 100, startDate: new Date('2024-01-01') }),
+    (error) => error instanceof AppError && error.statusCode === 400
+  );
+});


### PR DESCRIPTION
## Summary
- add a vanilla JS `<debtwise-dashboard>` component with login, demo data, charts, and strategy comparison views
- bundle static assets (HTML/CSS/JS) for the dashboard and serve them through the existing Node.js server
- document how to access the dashboard and reflect the new frontend module in the architecture overview

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe44657ec832eb4526ce403b7ec9a